### PR TITLE
Implement Stamina and Dash mechanics

### DIFF
--- a/entities/player.py
+++ b/entities/player.py
@@ -12,6 +12,19 @@ class Player(pygame.sprite.Sprite):
         self.image.fill((255, 0, 0))
         self.rect = self.image.get_rect(center=self.pos)
 
+        # Stamina and Dash attributes
+        self.stamina_max = 100.0
+        self.stamina_actual = 100.0
+        self.stamina_regen_rate = 20.0  # units per second
+        self.dash_cost = 30.0
+        self.dash_speed_multiplier = 3.0
+        self.dash_duration = 0.2  # seconds
+        self.dash_cooldown = 0.5  # seconds
+
+        self.is_dashing = False
+        self.dash_timer = 0.0
+        self.dash_cooldown_timer = 0.0
+
     def update(self, dt):
         self.direction = pygame.math.Vector2(0, 0)
         keys = pygame.key.get_pressed()
@@ -25,12 +38,39 @@ class Player(pygame.sprite.Sprite):
         if keys[pygame.K_d]:
             self.direction.x += 1
 
+        # Dash input handling
+        can_dash = (keys[pygame.K_SPACE] or keys[pygame.K_LSHIFT]) and not self.is_dashing and self.dash_cooldown_timer <= 0
+        if can_dash and self.direction.length() > 0 and self.stamina_actual >= self.dash_cost:
+            self.is_dashing = True
+            self.dash_timer = self.dash_duration
+            self.stamina_actual -= self.dash_cost
+
+        # Timers update
+        if self.dash_timer > 0:
+            self.dash_timer -= dt
+            if self.dash_timer <= 0:
+                self.is_dashing = False
+                self.dash_cooldown_timer = self.dash_cooldown
+
+        if self.dash_cooldown_timer > 0:
+            self.dash_cooldown_timer -= dt
+
         # Normalize direction vector to maintain constant speed in diagonals
         if self.direction.length() > 0:
             self.direction = self.direction.normalize()
 
+        # Apply dash speed multiplier
+        current_speed = self.speed
+        if self.is_dashing:
+            current_speed *= self.dash_speed_multiplier
+        else:
+            # Stamina regeneration
+            self.stamina_actual += self.stamina_regen_rate * dt
+            if self.stamina_actual > self.stamina_max:
+                self.stamina_actual = self.stamina_max
+
         # Update position based on direction, speed, and delta time
-        self.pos += self.direction * self.speed * dt
+        self.pos += self.direction * current_speed * dt
         self.rect.center = (round(self.pos.x), round(self.pos.y))
 
     def draw(self, surface):

--- a/states/game_state.py
+++ b/states/game_state.py
@@ -21,3 +21,13 @@ class GameState(State):
     def draw(self, surface):
         surface.fill(self.bg_color)
         self.player.draw(surface)
+
+        # Stamina UI
+        ui_x, ui_y = 20, 20
+        ui_width, ui_height = 200, 20
+        # Background bar
+        pygame.draw.rect(surface, (50, 50, 50), (ui_x, ui_y, ui_width, ui_height))
+        # Current stamina bar
+        stamina_ratio = self.player.stamina_actual / self.player.stamina_max
+        current_width = int(ui_width * stamina_ratio)
+        pygame.draw.rect(surface, (0, 200, 255), (ui_x, ui_y, current_width, ui_height))


### PR DESCRIPTION
This change adds a stamina-based dash mechanic to the player. The player can now press 'Space' or 'Shift' while moving to perform a quick dash, which consumes a portion of their stamina. Stamina regenerates over time when the player is not dashing. A visual representation of the stamina bar is also added to the game's UI.

Fixes #9

---
*PR created automatically by Jules for task [673283335340886986](https://jules.google.com/task/673283335340886986) started by @Villata-dev*