### PR TITLE
Implement TMX map loader and support

### DIFF
--- a/assets/maps/test_map.tmx
+++ b/assets/maps/test_map.tmx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="2" height="2" tilewidth="32" tileheight="32" infinite="0" nextlayerid="2" nextobjectid="1">
+ <layer id="1" name="Tile Layer 1" width="2" height="2">
+  <data encoding="csv">
+0,0,
+0,0
+</data>
+ </layer>
+</map>

--- a/engine/map_loader.py
+++ b/engine/map_loader.py
@@ -1,0 +1,34 @@
+import pytmx
+
+class TiledMap:
+    """
+    Class to load and handle TMX maps created with Tiled.
+    """
+    def __init__(self, filename):
+        """
+        Initializes the TiledMap by loading the TMX file.
+
+        Args:
+            filename (str): The path to the TMX file.
+        """
+        self.tmx_data = pytmx.load_pygame(filename, pixelalpha=True)
+        self.width = self.tmx_data.width * self.tmx_data.tilewidth
+        self.height = self.tmx_data.height * self.tmx_data.tileheight
+
+    def get_tile_properties(self, x, y, layer):
+        """
+        Gets the properties of a tile at a specific location and layer.
+
+        Args:
+            x (int): The x-coordinate of the tile.
+            y (int): The y-coordinate of the tile.
+            layer (int): The layer index.
+
+        Returns:
+            dict: The properties of the tile, or None if no properties exist.
+        """
+        try:
+            properties = self.tmx_data.get_tile_properties(x, y, layer)
+            return properties
+        except (ValueError, IndexError):
+            return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pygame
+pytmx

--- a/test_map_loader.py
+++ b/test_map_loader.py
@@ -1,0 +1,30 @@
+import os
+import pygame
+from engine.map_loader import TiledMap
+
+# Set SDL to dummy drivers for headless testing
+os.environ['SDL_VIDEODRIVER'] = 'dummy'
+os.environ['SDL_AUDIODRIVER'] = 'dummy'
+
+def test_map_loading():
+    pygame.init()
+    # Need a screen for some pygame functions (like loading images, though test_map.tmx doesn't have any tilesets yet)
+    pygame.display.set_mode((1, 1))
+
+    try:
+        map_path = "assets/maps/test_map.tmx"
+        tiled_map = TiledMap(map_path)
+        print(f"Map loaded successfully! Size: {tiled_map.width}x{tiled_map.height}")
+
+        # Test get_tile_properties (should be None for empty tiles in our dummy map)
+        props = tiled_map.get_tile_properties(0, 0, 0)
+        print(f"Properties at (0, 0, 0): {props}")
+
+    except Exception as e:
+        print(f"Error loading map: {e}")
+        exit(1)
+    finally:
+        pygame.quit()
+
+if __name__ == "__main__":
+    test_map_loading()


### PR DESCRIPTION
Integrated the `pytmx` library to support loading Tiled maps (.tmx). 
The implementation includes:
1. `engine/map_loader.py`: A `TiledMap` class that loads TMX data using `pytmx.load_pygame` and provides a `get_tile_properties` method.
2. `requirements.txt`: Updated to include the `pytmx` dependency.
3. `assets/maps/test_map.tmx`: A minimal TMX file for verification purposes.
4. `test_map_loader.py`: A script to verify the `TiledMap` class works as expected.

All tests passed in a headless environment, and the main game remains functional.

Fixes #17

---
*PR created automatically by Jules for task [8046183304508788447](https://jules.google.com/task/8046183304508788447) started by @Villata-dev*