### PR TITLE
Implement Layered Rendering for Tiled Maps

### DIFF
--- a/engine/map_loader.py
+++ b/engine/map_loader.py
@@ -14,6 +14,28 @@ class TiledMap:
         self.tmx_data = pytmx.load_pygame(filename, pixelalpha=True)
         self.width = self.tmx_data.width * self.tmx_data.tilewidth
         self.height = self.tmx_data.height * self.tmx_data.tileheight
+        self.offset = (0, 0)
+
+    def render(self, surface, layer_type=None):
+        """Renders the map layers to the surface, considering the camera offset.
+
+        Args:
+            surface (pygame.Surface): The surface to draw the tiles on.
+            layer_type (str, optional): Filters layers by name (e.g., 'Suelo' or 'Foreground').
+                                        If None, renders all visible non-object layers.
+        """
+        for layer in self.tmx_data.visible_layers:
+            # We only draw non-object layers here (e.g., Background/Foreground)
+            # Layers that need Y-sort are handled by sprites in the GameState.
+            if isinstance(layer, pytmx.TiledTileLayer) and "Objetos" not in layer.name:
+                if layer_type and layer_type not in layer.name:
+                    continue
+                for x, y, gid in layer:
+                    tile = self.tmx_data.get_tile_image_by_gid(gid)
+                    if tile:
+                        pos = (x * self.tmx_data.tilewidth + self.offset[0],
+                               y * self.tmx_data.tileheight + self.offset[1])
+                        surface.blit(tile, pos)
 
     def get_tile_properties(self, x, y, layer):
         """

--- a/entities/camera_group.py
+++ b/entities/camera_group.py
@@ -11,6 +11,19 @@ class CameraGroup(pygame.sprite.Group):
         """Initializes the CameraGroup."""
         super().__init__()
 
+    def get_offset(self, surface, target_sprite):
+        """Calculates the camera offset to center the target sprite on the surface.
+
+        Args:
+            surface (pygame.Surface): The surface where the game is being drawn.
+            target_sprite (pygame.sprite.Sprite): The sprite to center the camera on.
+
+        Returns:
+            pygame.math.Vector2: The calculated camera offset.
+        """
+        screen_center = pygame.math.Vector2(surface.get_width() // 2, surface.get_height() // 2)
+        return screen_center - pygame.math.Vector2(target_sprite.rect.center)
+
     def draw(self, surface, target_sprite):
         """Renders all sprites in the group with a camera offset and Y-sorting.
 
@@ -18,10 +31,8 @@ class CameraGroup(pygame.sprite.Group):
             surface (pygame.Surface): The surface to draw the sprites on.
             target_sprite (pygame.sprite.Sprite): The sprite to center the camera on.
         """
-        # Calculate offset: screen_center - target_position
-        # This keeps the target_sprite in the middle of the screen
-        screen_center = pygame.math.Vector2(surface.get_width() // 2, surface.get_height() // 2)
-        offset = screen_center - pygame.math.Vector2(target_sprite.rect.center)
+        # Calculate offset using the helper method
+        offset = self.get_offset(surface, target_sprite)
 
         # Sort sprites by their Y-coordinate (centery) for Y-Sort (pseudo-depth)
         # We use a custom sort to ensure sprites with higher Y are drawn later (on top)

--- a/entities/tile.py
+++ b/entities/tile.py
@@ -1,0 +1,21 @@
+import pygame
+
+class Tile(pygame.sprite.Sprite):
+    """A sprite representing a single tile from the map, used for Y-sorting.
+
+    Attributes:
+        image (pygame.Surface): The tile's graphic.
+        rect (pygame.Rect): The tile's position and size.
+    """
+
+    def __init__(self, pos, surface, groups):
+        """Initializes the Tile.
+
+        Args:
+            pos (tuple[int, int]): The top-left position of the tile in world coordinates.
+            surface (pygame.Surface): The tile's image.
+            groups (list[pygame.sprite.Group]): The sprite groups to add the tile to.
+        """
+        super().__init__(groups)
+        self.image = surface
+        self.rect = self.image.get_rect(topleft=pos)

--- a/states/game_state.py
+++ b/states/game_state.py
@@ -1,8 +1,11 @@
 import pygame
+import pytmx
 from states.state import State
 from entities.player import Player
 from entities.camera_group import CameraGroup
 from entities.obstacle import Obstacle
+from engine.map_loader import TiledMap
+from entities.tile import Tile
 
 class GameState(State):
     """Represents the main gameplay state.
@@ -30,22 +33,21 @@ class GameState(State):
         self.all_sprites = CameraGroup()
         self.obstacle_sprites = pygame.sprite.Group()
 
+        # Load Map
+        self.map = TiledMap("assets/maps/test_map.tmx")
+
         # Initialize player and add to group
         self.player = Player(400, 300, self.obstacle_sprites)
         self.all_sprites.add(self.player)
 
-        # Add some obstacles for Y-Sorting testing
-        # Some are placed relative to the player's initial position
-        obstacles_data = [
-            (300, 200, 60, 100, (0, 0, 200)),  # Top-left from player
-            (500, 350, 80, 60, (0, 50, 150)),  # Bottom-right from player
-            (400, 150, 50, 50, (20, 20, 100)), # Directly above player's initial pos
-            (200, 500, 100, 100, (0, 0, 180)), # Bottom-left
-            (600, 100, 40, 40, (10, 10, 80))   # Top-right
-        ]
-
-        for x, y, w, h, color in obstacles_data:
-            Obstacle([self.all_sprites, self.obstacle_sprites], x, y, w, h, color)
+        # Process Map Layers for Y-Sort (Objetos)
+        for layer in self.map.tmx_data.visible_layers:
+            if isinstance(layer, pytmx.TiledTileLayer) and "Objetos" in layer.name:
+                for x, y, gid in layer:
+                    tile_image = self.map.tmx_data.get_tile_image_by_gid(gid)
+                    if tile_image:
+                        pos = (x * self.map.tmx_data.tilewidth, y * self.map.tmx_data.tileheight)
+                        Tile(pos, tile_image, [self.all_sprites])
 
     def handle_events(self, events):
         """Handles gameplay events such as movement and combat.
@@ -78,8 +80,18 @@ class GameState(State):
         """
         surface.fill(self.bg_color)
 
-        # Draw all sprites with camera offset and Y-sorting
+        # Update map offset
+        offset = self.all_sprites.get_offset(surface, self.player)
+        self.map.offset = offset
+
+        # Draw Background Layers (e.g., Suelo)
+        self.map.render(surface, layer_type="Suelo")
+
+        # Draw all sprites with camera offset and Y-sorting (Player, Obstacles, Objetos)
         self.all_sprites.draw(surface, self.player)
+
+        # Draw Foreground Layers
+        self.map.render(surface, layer_type="Foreground")
 
         # Stamina UI (Keep it fixed on screen)
         ui_x, ui_y = 20, 20


### PR DESCRIPTION
This PR introduces a layered rendering system for Tiled maps, supporting Background ("Suelo"), Obstacles ("Objetos"), and Foreground layers. It refactors the CameraGroup to expose camera offset calculations and integrates map objects into the Y-sorting system using a new Tile class. The GameState now correctly manages the rendering order to ensure the player can walk behind certain objects.

Fixes #19

---
*PR created automatically by Jules for task [13165156028983543029](https://jules.google.com/task/13165156028983543029) started by @Villata-dev*