### PR TITLE
Import collisions and start points from Tiled

### DIFF
--- a/assets/maps/test_map.tmx
+++ b/assets/maps/test_map.tmx
@@ -1,9 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="2" height="2" tilewidth="32" tileheight="32" infinite="0" nextlayerid="2" nextobjectid="1">
- <layer id="1" name="Tile Layer 1" width="2" height="2">
+<map version="1.10" tiledversion="1.10.1" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="32" tileheight="32" infinite="0" nextlayerid="4" nextobjectid="3">
+ <layer id="1" name="Suelo" width="10" height="10">
   <data encoding="csv">
-0,0,
-0,0
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0
 </data>
  </layer>
+ <objectgroup id="2" name="Collisions">
+  <object id="1" x="64" y="64" width="64" height="64"/>
+ </objectgroup>
+ <objectgroup id="3" name="Entities">
+  <object id="2" name="Player_Start" x="160" y="160">
+   <point/>
+  </object>
+ </objectgroup>
 </map>

--- a/states/game_state.py
+++ b/states/game_state.py
@@ -36,18 +36,34 @@ class GameState(State):
         # Load Map
         self.map = TiledMap("assets/maps/test_map.tmx")
 
+        # Find Player_Start in Object Layers
+        player_x, player_y = 400, 300  # Default fallback
+        for layer in self.map.tmx_data.visible_layers:
+            if isinstance(layer, pytmx.TiledObjectGroup):
+                for obj in layer:
+                    if obj.name == "Player_Start":
+                        player_x, player_y = obj.x, obj.y
+                        break
+
         # Initialize player and add to group
-        self.player = Player(400, 300, self.obstacle_sprites)
+        self.player = Player(player_x, player_y, self.obstacle_sprites)
         self.all_sprites.add(self.player)
 
-        # Process Map Layers for Y-Sort (Objetos)
+        # Process Map Layers
         for layer in self.map.tmx_data.visible_layers:
+            # Tile layers that need Y-Sort (Objetos)
             if isinstance(layer, pytmx.TiledTileLayer) and "Objetos" in layer.name:
                 for x, y, gid in layer:
                     tile_image = self.map.tmx_data.get_tile_image_by_gid(gid)
                     if tile_image:
                         pos = (x * self.map.tmx_data.tilewidth, y * self.map.tmx_data.tileheight)
                         Tile(pos, tile_image, [self.all_sprites])
+
+            # Object layers for collisions
+            elif isinstance(layer, pytmx.TiledObjectGroup) and layer.name == "Collisions":
+                for obj in layer:
+                    # Creating invisible Obstacles for collision detection
+                    Obstacle([], obj.x, obj.y, obj.width, obj.height).add(self.obstacle_sprites)
 
     def handle_events(self, events):
         """Handles gameplay events such as movement and combat.


### PR DESCRIPTION
This PR implements the functionality to import player starting positions and collision boundaries directly from Tiled maps. Instead of hardcoding these values, the game now searches for a "Player_Start" object and a "Collisions" object layer within the loaded .tmx file. This change streamlines level design by allowing developers to define gameplay-critical areas within the Tiled editor.

Key changes:
- `GameState` now dynamically positions the player based on the TMX map.
- Collision rectangles from Tiled are now automatically converted into `Obstacle` sprites during state initialization.
- Added necessary layers to the test map to support these features.

Fixes #21

---
*PR created automatically by Jules for task [13410690955369936535](https://jules.google.com/task/13410690955369936535) started by @Villata-dev*